### PR TITLE
Fix code scanning alert no. 71: Database query built from user-controlled sources

### DIFF
--- a/routes/likeProductReviews.ts
+++ b/routes/likeProductReviews.ts
@@ -15,7 +15,7 @@ module.exports = function productReviews () {
   return (req: Request, res: Response, next: NextFunction) => {
     const id = req.body.id
     const user = security.authenticatedUsers.from(req)
-    db.reviewsCollection.findOne({ _id: id }).then((review: Review) => {
+    db.reviewsCollection.findOne({ _id: { $eq: id } }).then((review: Review) => {
       if (!review) {
         res.status(404).json({ error: 'Not found' })
       } else {
@@ -39,7 +39,7 @@ module.exports = function productReviews () {
                   }
                   challengeUtils.solveIf(challenges.timingAttackChallenge, () => { return count > 2 })
                   db.reviewsCollection.update(
-                    { _id: id },
+                    { _id: { $eq: id } },
                     { $set: { likedBy } }
                   ).then(
                     (result: any) => {

--- a/routes/updateProductReviews.ts
+++ b/routes/updateProductReviews.ts
@@ -15,7 +15,7 @@ module.exports = function productReviews () {
   return (req: Request, res: Response, next: NextFunction) => {
     const user = security.authenticatedUsers.from(req) // vuln-code-snippet vuln-line forgedReviewChallenge
     db.reviewsCollection.update( // vuln-code-snippet neutral-line forgedReviewChallenge
-      { _id: req.body.id }, // vuln-code-snippet vuln-line noSqlReviewsChallenge forgedReviewChallenge
+      { _id: { $eq: req.body.id } }, // vuln-code-snippet vuln-line noSqlReviewsChallenge forgedReviewChallenge
       { $set: { message: req.body.message } },
       { multi: true } // vuln-code-snippet vuln-line noSqlReviewsChallenge
     ).then(


### PR DESCRIPTION
Fixes [https://github.com/zkcilef/juice-shop-ghas-workshop/security/code-scanning/71](https://github.com/zkcilef/juice-shop-ghas-workshop/security/code-scanning/71)

To fix the problem, we need to ensure that the user input is interpreted as a literal value and not as a query object. This can be achieved by using the `$eq` operator in the MongoDB query. This approach ensures that the input is treated as a literal value, mitigating the risk of NoSQL injection.

- Modify the query on line 18 to use the `$eq` operator.
- No additional imports or dependencies are required for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
